### PR TITLE
Add ability to add feature default value

### DIFF
--- a/src/LaravelPlans/SubscriptionAbility.php
+++ b/src/LaravelPlans/SubscriptionAbility.php
@@ -123,4 +123,25 @@ class SubscriptionAbility
 
         return $default;
     }
+    
+    /**
+     * Add feature default value
+     *
+     * @param  string $feature
+     * @param  int $addValue
+     * @param  mixed $default
+     * @return mixed
+     */
+    public function addValue($feature, $addValue, $default = null)
+    {
+        foreach ($this->subscription->plan->features as $key => $value) {
+            if ($feature === $value->code) {
+                $value->value += $addValue;
+                $value->save();
+                return $value->value;
+            }
+        }
+
+        return $default;
+    }
 }


### PR DESCRIPTION
Usage Case - Add-ons to add feature value only
- we have feature name `listings` with default value => 2
- we can create add-ons with single feature which is add `listings` value by 10
- when user add this add-ons, we addValue : 
```
$user->subscription('main')->ability()->addValue('listings', 10);
```
- so the final listings value only for current user will be => 12

